### PR TITLE
fix: 解决 Base64 长度不为 4 的倍数的问题

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -53,7 +53,14 @@ func GetSub(url string, ch chan<- []string) {
 		}
 	}
 
-	res, err := base64.StdEncoding.DecodeString(string(body))
+	bodyStr := string(body)
+	complementLen := (4 - (len(bodyStr) % 4)) % 4
+
+	for i := 0; i < complementLen; i++ {
+		bodyStr += "="
+	}
+
+	res, err := base64.StdEncoding.DecodeString(bodyStr)
 	if err != nil {
 		ch <- nil
 		return // send nil


### PR DESCRIPTION
由于 = 字符也可能出现在 Base64 编码中，但 = 用在 URL、Cookie 里面会
造成歧义，所以，很多 Base64 编码后会把 = 去掉。
> 参考廖雪峰对 Base64
的讲解：https://www.liaoxuefeng.com/wiki/1016959663602400/1017684507717184

另外在 Base64 中 = 主要用于代表补足的字节数。只会出现在末尾
> 具体情况将 Wiki:
https://zh.wikipedia.org/wiki/Base64#%E7%A4%BA%E4%BE%8B

所以这里的修复为：
- 先判断请求订阅地址得到的 Base64 内容是否为 4 的倍数
  - 如果不为 4 的倍数，就用 = 补成 4 的倍数。
  - 如果为 4 的倍数，不做处理
- 进行 Base64 解析

----

个人也是在使用过程中遇到的问题，每次提交订阅链接，就给我报错 **Base64** 解析错误。所以就看了看源码，原来是 Base64 的一些小问题。